### PR TITLE
Changes to enable PGO builds on ci_slave and pssprotobuild

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -149,7 +149,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
   config.vm.provider :virtualbox do |v|
-      v.customize ["modifyvm", :id, "--memory", "1024"]
+      v.customize ["modifyvm", :id, "--memory", "4096"]
   end
 
   # Create a forwarded port mapping which allows access jenkins via host port 1234

--- a/puppet/modules/boost/manifests/params.pp
+++ b/puppet/modules/boost/manifests/params.pp
@@ -8,7 +8,7 @@ class boost::params {
       $boost_packages = [ 'boost' ]
     }
     'Debian': {
-      $boost_packages = [ 'libboost-dev', 'libboost-program-options-dev' ]
+      $boost_packages = [ 'libboost-all-dev', 'libboost-filesystem-dev' ]
     }
     default: {
       fail("Class['boost::params']: Unsupported osfamily: ${::osfamily}")

--- a/puppet/modules/ci_slave/manifests/init.pp
+++ b/puppet/modules/ci_slave/manifests/init.pp
@@ -11,6 +11,7 @@ class ci_slave (
     require lapack
     require blas
     require lcov
+    require boost
 
     Package { ensure => "installed" }
 

--- a/puppet/modules/pssprotobuild/manifests/init.pp
+++ b/puppet/modules/pssprotobuild/manifests/init.pp
@@ -11,6 +11,7 @@ class pssprotobuild (
     require lapack
     require blas
     require lcov
+    require boost
 
     Package { ensure => "installed" }
 


### PR DESCRIPTION
These changes where required to get a vagrant spin capable of compiling a profiled optimisation - ci_slave (and pssprotobuild) should both be capable of this, and so modifications have been made to both.
